### PR TITLE
Create OPT_Resource_Defaults.cfg

### DIFF
--- a/MM_Patches/OPT_Resource_Defaults.cfg
+++ b/MM_Patches/OPT_Resource_Defaults.cfg
@@ -1,0 +1,353 @@
+// Fallback defaults for when no fuel tank management plugins are installed
+// (i.e, pure stock)
+@PART[ij_adaptor]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 720
+		maxAmount = 720
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 880
+		maxAmount = 880
+	}
+}
+
+@PART[ij_4m_adaptor_variant]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 576
+		maxAmount = 576
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 704
+		maxAmount = 704
+	}
+}
+
+@PART[phoenix_cockpit]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 144
+		maxAmount = 144
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 176
+		maxAmount = 176
+	}
+}
+
+@PART[jk_3m_adaptor]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 1080
+		maxAmount = 1080
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 1320
+		maxAmount = 1320
+	}
+}
+
+@PART[jk_7m_adaptor]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 2160
+		maxAmount = 2160
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 2640
+		maxAmount = 2640
+	}
+}
+
+@PART[j_2m_bicoupler]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 540
+		maxAmount = 540
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 660
+		maxAmount = 660
+	}
+}
+
+@PART[j_2m_tanks]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 648
+		maxAmount = 648
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 792
+		maxAmount = 792
+	}
+}
+
+@PART[j_4m_cargo]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 540
+		maxAmount = 540
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 660
+		maxAmount = 660
+	}
+}
+
+@PART[j_4m_crew]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 900
+		maxAmount = 900
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 1100
+		maxAmount = 1100
+	}
+}
+
+@PART[j_4m_tanks]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 1332
+		maxAmount = 1332
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 1628
+		maxAmount = 1628
+	}
+}
+
+@PART[j_5m_nose]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 360
+		maxAmount = 360
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 440
+		maxAmount = 440
+	}
+}
+
+@PART[j_5m_tail]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 360
+		maxAmount = 360
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 440
+		maxAmount = 440
+	}
+}
+
+@PART[j_cockpit]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 180
+		maxAmount = 180
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 220
+		maxAmount = 220
+	}
+}
+
+@PART[k_8m_cockpit]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 360
+		maxAmount = 360
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 440
+		maxAmount = 440
+	}
+}
+
+@PART[k_2m_bicoupler]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 1080
+		maxAmount = 1080
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 1320
+		maxAmount = 1320
+	}
+}
+
+@PART[k_3m_fuselage]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 612
+		maxAmount = 612
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 748
+		maxAmount = 748
+	}
+}
+
+@PART[k_6m_cargo]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 1260
+		maxAmount = 1260
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 1540
+		maxAmount = 1540
+	}
+}
+
+@PART[k_6m_fuelTank]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 2340
+		maxAmount = 2340
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 2860
+		maxAmount = 2860
+	}
+}
+
+@PART[k_6m_fuselage]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 1260
+		maxAmount = 1260
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 1540
+		maxAmount = 1540
+	}
+}
+
+@PART[k_7m_cargoTail_variant]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 360
+		maxAmount = 360
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 440
+		maxAmount = 440
+	}
+}
+
+@PART[mk2j_adaptor]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 504
+		maxAmount = 504
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 616
+		maxAmount = 616
+	}
+}
+
+@PART[mk2_nose_opt]:NEEDS[!Firespitter,!RealFuels,!ModularFuelTanks]
+{
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 252
+		maxAmount = 252
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 308
+		maxAmount = 308
+	}
+}


### PR DESCRIPTION
These configs take effect if no fuel tank management plugins are installed. Firespitter, RealFuels and ModularFuelTanks are checked for. (RF and MFT configs will be following in the next day or so)