### PR TITLE
Update OPT_j_sas.cfg

### DIFF
--- a/Parts/Juno/OPT_j_sas.cfg
+++ b/Parts/Juno/OPT_j_sas.cfg
@@ -36,6 +36,7 @@ MODEL
 {
 model = OPT/Parts/Juno/OPT_j_sas
 texture = texture_main_1, OPT/Textures/texture_main_1
+texture = texture_EMM_main_1, OPT/Textures/texture_EMM_main_1
 }
 node_stack_top=0.0, 0.16248, 0, 0.0, 1.0, 0.0, 4
 node_stack_bottom=0.0, -0.16248, 0, 0.0, -1.0, 0.0, 4


### PR DESCRIPTION
The "Juno" SAS uses an emissive texture for the glowing lights on the panels so I think you may need to include it in your offset.